### PR TITLE
Do not use "record" in exceptions, as it could be huge in malformed MRT.

### DIFF
--- a/src/org/javamrt/mrt/BGPFileReader.java
+++ b/src/org/javamrt/mrt/BGPFileReader.java
@@ -204,7 +204,7 @@ public class BGPFileReader {
 			if (leidos != this.record.length) {
 				this.eof = true;
 				throw new BGPFileReaderException("Truncated file: " + leidos
-						+ " instead of " + this.record.length + " bytes",record);
+						+ " instead of " + this.record.length + " bytes", header);
 			}
 
 			/*
@@ -647,7 +647,7 @@ public class BGPFileReader {
 		if (recordFifo.isEmpty()) {
 			if (Debug.compileDebug)
 				if (Debug.doDebug)
-					throw new BGPFileReaderException("recordFifo empty!", record);
+					throw new BGPFileReaderException("recordFifo empty!", header);
 			return null;
 		}
 		return recordFifo.remove();


### PR DESCRIPTION
While trying to parse malformed MRT with BGPFileReader, it "hangs" in creating the BGPFileReaderException, because the recordlen (and, respectively, record) could be surprisingly big in a malformed MRT record.