### PR TITLE
Objects reuse bugfix, lenient mode, and old objects support

### DIFF
--- a/src/main/java/org/javamrt/mrt/AS.java
+++ b/src/main/java/org/javamrt/mrt/AS.java
@@ -7,7 +7,9 @@
 package org.javamrt.mrt;
 
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 
 /**
  * @author paag
@@ -145,5 +147,12 @@ public class AS implements Comparable<AS>, Comparator<AS> {
 			throw new Exception ("Incorrect AS specification: "+asspec);
 		}
 		return result;
+	}
+
+	/**
+	 * @return list of ASNs, especially useful when not interested in whether it is some type of set, but just want to deal with the numbers
+	 */
+	public List<AS> getASList() {
+		return Collections.singletonList(this);
 	}
 }

--- a/src/main/java/org/javamrt/mrt/ASConfedSequence.java
+++ b/src/main/java/org/javamrt/mrt/ASConfedSequence.java
@@ -6,22 +6,19 @@
 
 package org.javamrt.mrt;
 
+import java.util.List;
 import java.util.LinkedList;
+import java.util.stream.Collectors;
 
-public class ASConfedSequence
-	extends AS
-{
-	LinkedList<AS> asList;
+public class ASConfedSequence extends AS {
+    LinkedList<AS> asList;
 
-	public ASConfedSequence(LinkedList<AS> asList) {
-		this.asList = new LinkedList<AS>();
-		this.asList.addAll(asList);
-	}
+    public ASConfedSequence(List<AS> asList) {
+        this.asList = new LinkedList<>();
+        this.asList.addAll(asList);
+    }
 
-	public String toString() {
-		String result = "[";
-		for (AS as:asList)
-			result = result.concat(" "+as.toString());
-		return result.concat(" ]");
-	}
+    public String toString() {
+        return asList.stream().map(AS::toString).collect(Collectors.joining(" ", "[", "]"));
+    }
 }

--- a/src/main/java/org/javamrt/mrt/ASConfedSequence.java
+++ b/src/main/java/org/javamrt/mrt/ASConfedSequence.java
@@ -18,7 +18,13 @@ public class ASConfedSequence extends AS {
         this.asList.addAll(asList);
     }
 
+    @Override
     public String toString() {
         return asList.stream().map(AS::toString).collect(Collectors.joining(" ", "[", "]"));
+    }
+
+    @Override
+    public List<AS> getASList() {
+        return this.asList;
     }
 }

--- a/src/main/java/org/javamrt/mrt/ASConfedSet.java
+++ b/src/main/java/org/javamrt/mrt/ASConfedSet.java
@@ -7,22 +7,20 @@
 package org.javamrt.mrt;
 
 import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ASConfedSet extends AS {
 
-	private LinkedList<AS> asList;
+    private LinkedList<AS> asList;
 
-	public ASConfedSet(LinkedList<AS> asList) {
-		this.asList = new LinkedList<AS>();
-		this.asList.addAll(asList);
-	}
+    public ASConfedSet(final List<AS> asList) {
+        this.asList = new LinkedList<>();
+        this.asList.addAll(asList);
+    }
 
-
-	public String toString() {
-		String result = "{";
-		for (AS as:asList)
-			result = result.concat(" "+as.toString());
-		return result.concat(" }");
-	}
+    public String toString() {
+        return asList.stream().map(AS::toString).collect(Collectors.joining(" ", "{", "}"));
+    }
 }
 

--- a/src/main/java/org/javamrt/mrt/ASConfedSet.java
+++ b/src/main/java/org/javamrt/mrt/ASConfedSet.java
@@ -19,8 +19,14 @@ public class ASConfedSet extends AS {
         this.asList.addAll(asList);
     }
 
+    @Override
     public String toString() {
         return asList.stream().map(AS::toString).collect(Collectors.joining(" ", "{", "}"));
+    }
+
+    @Override
+    public List<AS> getASList() {
+        return this.asList;
     }
 }
 

--- a/src/main/java/org/javamrt/mrt/ASPath.java
+++ b/src/main/java/org/javamrt/mrt/ASPath.java
@@ -82,9 +82,8 @@ public class ASPath implements Attribute {
 		try {
 			return path.get(i);
 		} catch (IndexOutOfBoundsException iobe) {
-			//
+			return null;
 		}
-		return null;
 	}
 
 	public void set(int index,AS element) {

--- a/src/main/java/org/javamrt/mrt/ASPath.java
+++ b/src/main/java/org/javamrt/mrt/ASPath.java
@@ -6,314 +6,414 @@
 
 package org.javamrt.mrt;
 
-import java.util.LinkedList;
-import java.util.Vector;
-
 import org.javamrt.utils.RecordAccess;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Vector;
+import java.util.function.BiConsumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 
 /**
- *
  * ASPath is a linked list of elements which are either <br>
  * AS, ASSet or ASConfedSet
  * <br><br>
  * version 3.00: complete rewrite with ASPathSegment<br>
  *
- * @version 3.00
  * @author paag
+ * @version 3.00
  */
 public class ASPath implements Attribute {
-	protected LinkedList<AS> path;
 
-	ASPath() {
-		this.path = new LinkedList<AS>();
-		this.prependers = null;
-	}
+    private enum StringParser {
+        SET("(", ")", (acc, elements) -> acc.add(new ASSet(elements))),
+        CONFED_SET("{", "}", (acc, elements) -> acc.add(new ASConfedSet(elements))),
+        CONFED_SEQ("[", "]", (acc, elements) -> acc.add(new ASConfedSequence(elements))),
+        AS("", "", List::addAll);
+
+        private final static Pattern PATH_ELEMENT_FINDER;
+        private final static Pattern AS_NUMBER_FINDER;
+
+        static {
+            final List<String> expressionStrings = Arrays
+                    .stream(StringParser.values())
+                    .map(parseInfo -> String.format("%s((?:\\s?\\d\\s?)+)%s", parseInfo.start, parseInfo.end))
+                    .collect(Collectors.toList());
+
+            PATH_ELEMENT_FINDER = Pattern.compile(String.join("|", expressionStrings));
+            AS_NUMBER_FINDER = Pattern.compile("\\d+");
+        }
+
+        private final String start;
+        private final String end;
+        private final BiConsumer<List<AS>, LinkedList<AS>> appender;
+
+        StringParser(final String start, final String end, BiConsumer<List<AS>, LinkedList<AS>> appender) {
+            this.start = Pattern.quote(start);
+            this.end = Pattern.quote(end);
+            this.appender = appender;
+        }
+
+        static List<AS> parse(final String input) {
+            final List<AS> result = new LinkedList<>();
+            final Matcher pathElementMatcher = PATH_ELEMENT_FINDER.matcher(input);
+            while (pathElementMatcher.find()) {
+                for (final StringParser parser : StringParser.values()) {
+                    final String group = pathElementMatcher.group(1 + parser.ordinal());
+                    if (group != null) {
+                        final LinkedList<AS> elements = new LinkedList<>();
+                        final Matcher asMatcher = AS_NUMBER_FINDER.matcher(group);
+                        while (asMatcher.find()) {
+                            elements.add(new AS(Long.parseLong(asMatcher.group())));
+                        }
+
+                        parser.appender.accept(result, elements);
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+
+    protected LinkedList<AS> path;
+
+    ASPath() {
+        this.path = new LinkedList<>();
+        this.prependers = null;
+    }
+
+    ASPath(final List<AS> path) {
+        this.path = new LinkedList<>();
+        this.path.addAll(path);
+    }
 
 //	ASPath(byte[] buffer) throws Exception {
 //		decode(buffer, 2);
 //	}
 
-	ASPath(byte[] buffer, int asSize) throws Exception {
-		decode(buffer, asSize);
-	}
+    ASPath(byte[] buffer, int asSize) throws Exception {
+        decode(buffer, asSize);
+    }
 
 
-	private void decode(byte[] buffer, int asSize) throws Exception {
-		this.path = new LinkedList<AS>();
-		int offset = 0;
-		// route_btoa.System_err_println(String.format("New ASPATH (%d bytes)",buffer.length));
-		while (offset < buffer.length) {
-			ASPathSegment segment = new ASPathSegment(buffer, offset, asSize);
-			// route_btoa.System_err_println(String.format("  segment @%-2d [t %2d]: %s\n",offset,segment.bType(),segment.toString()));
-			switch (segment.bType()) {
-			case MRTConstants.asSequence:
-				this.path.addAll(segment.getASList());
-				break;
-			case MRTConstants.asSet:
-				if (null != segment.getAS())
-					this.path.add(segment.getAS());
-				else
-					this.path.add(new ASSet(segment.getASList()));
-				break;
-			case MRTConstants.asConfedSequence:
-				this.add(new ASConfedSequence(segment.getASList()));
-				break;
-			case MRTConstants.asConfedSet:
-				this.add(new ASConfedSet(segment.getASList()));
-				break;
-			default:
-				RecordAccess.dump(buffer);
-				throw new Exception(
-					String.format("Unknown ASPATH Segment Type = %d Len = %d",
-								  segment.bType(), segment.bLen())
-				);
-			}
-			offset+=segment.bLen();
-		}
-		//
-		// and now try to see if we have AS PATH Prepend
-		//
-		mkPrependers();
-		// route_btoa.System_err_println("New ASPATH:"+path.toString());
-	}
+    private void decode(byte[] buffer, int asSize) throws Exception {
+        this.path = new LinkedList<AS>();
+        int offset = 0;
+        // route_btoa.System_err_println(String.format("New ASPATH (%d bytes)",buffer.length));
+        while (offset < buffer.length) {
+            ASPathSegment segment = new ASPathSegment(buffer, offset, asSize);
+            // route_btoa.System_err_println(String.format("  segment @%-2d [t %2d]: %s\n",offset,segment.bType(),segment.toString()));
+            switch (segment.bType()) {
+                case MRTConstants.asSequence:
+                    this.path.addAll(segment.getASList());
+                    break;
+                case MRTConstants.asSet:
+                    if (null != segment.getAS()) {
+                        this.path.add(segment.getAS());
+                    } else {
+                        this.path.add(new ASSet(segment.getASList()));
+                    }
+                    break;
+                case MRTConstants.asConfedSequence:
+                    this.add(new ASConfedSequence(segment.getASList()));
+                    break;
+                case MRTConstants.asConfedSet:
+                    this.add(new ASConfedSet(segment.getASList()));
+                    break;
+                default:
+                    RecordAccess.dump(buffer);
+                    throw new Exception(
+                            String.format("Unknown ASPATH Segment Type = %d Len = %d",
+                                          segment.bType(), segment.bLen())
+                    );
+            }
+            offset += segment.bLen();
+        }
+        //
+        // and now try to see if we have AS PATH Prepend
+        //
+        mkPrependers();
+        // route_btoa.System_err_println("New ASPATH:"+path.toString());
+    }
 
-	public AS get(int i) {
-		try {
-			return path.get(i);
-		} catch (IndexOutOfBoundsException iobe) {
-			return null;
-		}
-	}
+    public AS get(int i) {
+        try {
+            return path.get(i);
+        } catch (IndexOutOfBoundsException iobe) {
+            return null;
+        }
+    }
 
-	public void set(int index,AS element) {
-		path.set(index, element);
-	}
-	/**
-	 * Append an AS to the ASPATH
-	 * @param as
-	 */
-	public void append(AS as) {
-		add(as);
-	}
+    public void set(int index, AS element) {
+        path.set(index, element);
+    }
 
-	/**
-	 * alias of append(AS as)
-	 * @param as
-	 */
-	public void add(AS as) {
-		path.add(as);
-		refreshPrependers(as);
-	}
+    /**
+     * Append an AS to the ASPATH
+     *
+     * @param as
+     */
+    public void append(AS as) {
+        add(as);
+    }
 
-	public LinkedList<AS> getPath() {
-		return this.path;
-	}
-	/**
-	 *
-	 * @return the number of hops of the ASPATH
-	 */
-	public int length() {
-		return path.size();
-	}
+    /**
+     * alias of append(AS as)
+     *
+     * @param as
+     */
+    public void add(AS as) {
+        path.add(as);
+        refreshPrependers(as);
+    }
 
-	/**
-	 * @author paag
-	 * @return a Vector with the AS's which are doing prepending.
-	 */
-	public Vector<AS> getPrependers() {
-		return prependers;
-	}
+    public LinkedList<AS> getPath() {
+        return this.path;
+    }
 
-	/**
-	 *
-	 * @return
-	 */
-	public boolean hasAsPathPrepend() {
-		return prependers != null;
-	}
+    /**
+     * @return the number of hops of the ASPATH
+     */
+    public int length() {
+        return path.size();
+    }
 
-	/**
-	 * @author paag
-	 * rebuild the PREPENDER list
-	 *  <br>Called from decode() or when the AS4PATH attribute is decoded
-	 */
-	public void mkPrependers() {
-		int asPathLen;
+    /**
+     * @return a Vector with the AS's which are doing prepending.
+     * @author paag
+     */
+    public Vector<AS> getPrependers() {
+        return prependers;
+    }
 
-		this.prependers = null;
-		if ((asPathLen = this.path.size()) == 0)
-			return;
-		for (int i=0; i<asPathLen;i++) {
-			AS ahora = this.path.get(i);
-			if (i != this.path.lastIndexOf(ahora)) {
-				if (prependers == null)
-					prependers = new Vector<AS>();
-				prependers.add(ahora);
-				i = this.path.lastIndexOf(ahora);
-			}
-		}
-	}
-	/**
-	 * refresh the prependers list when an AS is appended to the ASPATH
-	 * @param ultimo the AS which was appended to the ASPATH
-	 * @author paag
-	 */
-	private void refreshPrependers(AS ultimo) {
-		//
-		// is the argument involved in AS PATH prepending?
-		//
-		if (this.path.indexOf(ultimo) == this.path.lastIndexOf(ultimo))
-			return;
-		try {
-			//
-			// did we already register AS PATH prepending for the argument?
-			//
-			if (prependers.contains(ultimo))
-				return;
-		} catch (Exception e) {
-			//
-			// no prependers yet
-			//
-			prependers = new Vector<AS>();
-		}
-		prependers.add(ultimo);
-	}
+    /**
+     * @return
+     */
+    public boolean hasAsPathPrepend() {
+        return prependers != null;
+    }
 
-	/**
-	 * @param as: an AS
-	 * @return the index of the first occurrence of AS in the ASPATH
-	 */
-	public int indexOf(AS as) {
-		return this.path.indexOf(as);
-	}
+    /**
+     * @author paag
+     *         rebuild the PREPENDER list
+     *         <br>Called from decode() or when the AS4PATH attribute is decoded
+     */
+    public void mkPrependers() {
+        int asPathLen;
 
-	/**
-	 * @param as: an AS
-	 * @return the index of the last occurrence of AS in the ASPATH
-	 */
-	public int lastIndexOf(AS as) {
-		return this.path.lastIndexOf(as);
-	}
+        this.prependers = null;
+        if ((asPathLen = this.path.size()) == 0) {
+            return;
+        }
+        for (int i = 0; i < asPathLen; i++) {
+            AS ahora = this.path.get(i);
+            if (i != this.path.lastIndexOf(ahora)) {
+                if (prependers == null) {
+                    prependers = new Vector<AS>();
+                }
+                prependers.add(ahora);
+                i = this.path.lastIndexOf(ahora);
+            }
+        }
+    }
 
-	public boolean contains(AS as) {
-		return this.path.indexOf(as) != -1;
-	}
-	/**
-	 * @author paag
-	 * @return a textual representation of the ASPATH
-	 */
-	public String toString() {
-		try {
-			if (this.path.size() == 0)
-				return "";
+    /**
+     * refresh the prependers list when an AS is appended to the ASPATH
+     *
+     * @param ultimo the AS which was appended to the ASPATH
+     * @author paag
+     */
+    private void refreshPrependers(AS ultimo) {
+        //
+        // is the argument involved in AS PATH prepending?
+        //
+        if (this.path.indexOf(ultimo) == this.path.lastIndexOf(ultimo)) {
+            return;
+        }
+        try {
+            //
+            // did we already register AS PATH prepending for the argument?
+            //
+            if (prependers.contains(ultimo)) {
+                return;
+            }
+        } catch (Exception e) {
+            //
+            // no prependers yet
+            //
+            prependers = new Vector<AS>();
+        }
+        prependers.add(ultimo);
+    }
 
-			String result = null;
-			for (int i = 0; i < this.path.size(); i++)
-				try {
-					result = result.concat(" "+this.path.get(i).toString());
-				} catch (Exception e) {
-					result = this.path.get(i).toString();
-				}
-			return result;
-		}catch (Exception e) {
-			return "";
-		}
-	}
+    /**
+     * @param as: an AS
+     * @return the index of the first occurrence of AS in the ASPATH
+     */
+    public int indexOf(AS as) {
+        return this.path.indexOf(as);
+    }
 
-	/**
-	 * Shortcut for equals(Object o)
-	 * @param ASPath other: an other ASPath
-	 * @return true if both have the same length and all AS's in them are in the same place.
-	 * @author paag
-	 */
-	public boolean equals(ASPath other) {
-		if (this.path.size() != other.path.size())
-			return false;
+    /**
+     * @param as: an AS
+     * @return the index of the last occurrence of AS in the ASPATH
+     */
+    public int lastIndexOf(AS as) {
+        return this.path.lastIndexOf(as);
+    }
 
-		for (int i = 0; i < this.path.size(); i++)
-			if (!this.path.get(i).equals(other.path.get(i)))
-				return false;
+    public boolean contains(AS as) {
+        return this.path.indexOf(as) != -1;
+    }
 
-		return true;
-	}
+    /**
+     * @return a textual representation of the ASPATH
+     * @author paag
+     */
+    public String toString() {
+        try {
+            if (this.path.size() == 0) {
+                return "";
+            }
 
-	/**
-	 * This is the canonical implementation of the equals() method
-	 * @param Object o
-	 * <br>
-	 */
-	public boolean equals(Object o) {
-		if (o == null)
-			return false;
-		if (o == this)
-			return true;
-		if (o instanceof ASPath)
-			return this.equals((ASPath)o);
-		return false;
-	}
+            String result = null;
+            for (int i = 0; i < this.path.size(); i++)
+                try {
+                    result = result.concat(" " + this.path.get(i).toString());
+                } catch (Exception e) {
+                    result = this.path.get(i).toString();
+                }
+            return result;
+        } catch (Exception e) {
+            return "";
+        }
+    }
 
-	/**
-	 *
-	 * @param as: as Autonomous System
-	 * @return true if as generated the prefix
-	 */
-	public boolean isGenerator(AS as) {
-		return as.equals(this.path.getLast());
-	}
+    /**
+     * Construct an ASPath from the textual representation
+     *
+     * @param input The input to parse.
+     * @return The parsed ASPath
+     */
+    public static ASPath fromString(final String input) {
+        return new ASPath(StringParser.parse(input));
+    }
 
-	/**
-	 *
-	 * @return the As which generated the prefix
-	 */
-	public AS generator() {
-		try {
-			return this.path.getLast();
-		} catch (Exception e) {
-			return AS.NullAS;
-		}
-	}
-	/**
-	 * Build a copy of the AS_PATH but without prepends
-	 * @param none
-	 * @author paag
-	 */
+    /**
+     * Shortcut for equals(Object o)
+     *
+     * @param other: an other ASPath
+     * @return true if both have the same length and all AS's in them are in the same place.
+     * @author paag
+     */
+    public boolean equals(ASPath other) {
+        if (this.path.size() != other.path.size()) {
+            return false;
+        }
 
-	public ASPath canonicalPath() {
-		ASPath canonical = new ASPath();
+        for (int i = 0; i < this.path.size(); i++)
+            if (!this.path.get(i).equals(other.path.get(i))) {
+                return false;
+            }
 
-		for (int i = 0; i < this.path.size(); i++) {
-			AS as = this.path.get(i);
-			canonical.add(as);
-			i = this.path.lastIndexOf(as);
-		}
-		return canonical;
-	}
+        return true;
+    }
 
-	private Vector<AS> prependers;
+    /**
+     * This is the canonical implementation of the equals() method
+     *
+     * @param o <br>
+     */
+    public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
+        if (o == this) {
+            return true;
+        }
+        if (o instanceof ASPath) {
+            return this.equals((ASPath) o);
+        }
+        return false;
+    }
 
-	/**
-	 *
-	 * @return true if the originating AS is prepending
-	 */
-	public boolean hasOriginPrepend() {
-		try {
-			return this.prependers.contains(this.generator());
-		} catch (NullPointerException npe) {
-			return false;
-		}
-	}
+    /**
+     * @param as: as Autonomous System
+     * @return true if as generated the prefix
+     */
+    public boolean isGenerator(AS as) {
+        return as.equals(this.path.getLast());
+    }
 
-	public int compareTo(ASPath aspath) {
-		int result = 0;
-		if (this.equals(aspath)) return 0;
-		if (this.length() != aspath.length())
-			return this.length() > aspath.length() ? 1 : -1;
-		for (int i=0; i < this.length(); i++) {
-			result = this.get(i).compareTo(aspath.get(i));
-			if (result == 0)
-				return result;
-		}
-		return result;
-	}
+    /**
+     * @return the As which generated the prefix
+     */
+    public AS generator() {
+        try {
+            return this.path.getLast();
+        } catch (Exception e) {
+            return AS.NullAS;
+        }
+    }
+
+    /**
+     * Build a copy of the AS_PATH but without prepends
+     *
+     * @author paag
+     */
+
+    public ASPath canonicalPath() {
+        ASPath canonical = new ASPath();
+
+        for (int i = 0; i < this.path.size(); i++) {
+            AS as = this.path.get(i);
+            canonical.add(as);
+            i = this.path.lastIndexOf(as);
+        }
+        return canonical;
+    }
+
+    private Vector<AS> prependers;
+
+    /**
+     * @return true if the originating AS is prepending
+     */
+    public boolean hasOriginPrepend() {
+        try {
+            return this.prependers.contains(this.generator());
+        } catch (NullPointerException npe) {
+            return false;
+        }
+    }
+
+    public int compareTo(ASPath aspath) {
+        int result = 0;
+        if (this.equals(aspath)) {
+            return 0;
+        }
+        if (this.length() != aspath.length()) {
+            return this.length() > aspath.length() ? 1 : -1;
+        }
+        for (int i = 0; i < this.length(); i++) {
+            result = this.get(i).compareTo(aspath.get(i));
+            if (result == 0) {
+                return result;
+            }
+        }
+        return result;
+    }
+
+    public AS getOriginating() {
+        return path.isEmpty() ? null : path.getLast();
+    }
+
+    public List<AS> getTransiting() {
+        return path.isEmpty() ? Collections.emptyList() : path.subList(0, path.size() - 1);
+    }
 }

--- a/src/main/java/org/javamrt/mrt/ASPath.java
+++ b/src/main/java/org/javamrt/mrt/ASPath.java
@@ -277,19 +277,12 @@ public class ASPath implements Attribute {
      * @author paag
      */
     public String toString() {
-        try {
-            if (this.path.size() == 0) {
-                return "";
-            }
+        return asString(this.path);
+    }
 
-            String result = null;
-            for (int i = 0; i < this.path.size(); i++)
-                try {
-                    result = result.concat(" " + this.path.get(i).toString());
-                } catch (Exception e) {
-                    result = this.path.get(i).toString();
-                }
-            return result;
+    public static String asString(final List<AS> path) {
+        try {
+            return path.stream().map(AS::toString).collect(Collectors.joining(" "));
         } catch (Exception e) {
             return "";
         }

--- a/src/main/java/org/javamrt/mrt/ASSet.java
+++ b/src/main/java/org/javamrt/mrt/ASSet.java
@@ -40,6 +40,7 @@ public class ASSet extends AS
 		return asSet.hashCode();
 	}
 
+	@Override
 	public List<AS> getASList() {
 		return this.asSet;
 	}

--- a/src/main/java/org/javamrt/mrt/ASSet.java
+++ b/src/main/java/org/javamrt/mrt/ASSet.java
@@ -9,6 +9,7 @@ package org.javamrt.mrt;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 // import org.javamrt.utils.RecordAccess;
 
@@ -60,10 +61,7 @@ public class ASSet extends AS
 	}
 
 	public String toString() {
-		String result = "(".concat(this.asSet.get(0).toString());
-		for (int i = 1; i < asSet.size(); i++)
-			result = result.concat(" ").concat(this.asSet.get(i).toString());
-		return result.concat(")");
+		return asSet.stream().map(AS::toString).collect(Collectors.joining(" ", "(", ")"));
 	}
 
 }

--- a/src/main/java/org/javamrt/mrt/Attributes.java
+++ b/src/main/java/org/javamrt/mrt/Attributes.java
@@ -6,6 +6,7 @@
 
 package org.javamrt.mrt;
 
+import org.javamrt.progs.route_btoa;
 import org.javamrt.utils.Debug;
 import org.javamrt.utils.RecordAccess;
 
@@ -254,7 +255,7 @@ public class Attributes {
                                 break;
 
 				default:
-					attributes.set(type, new UnsupportedAttribute(type, buffer));
+					route_btoa.System_err_println("Ignoring unknown attribute type " + type);
 					break;
 			}
 		}

--- a/src/main/java/org/javamrt/mrt/Attributes.java
+++ b/src/main/java/org/javamrt/mrt/Attributes.java
@@ -273,7 +273,7 @@ public class Attributes {
 		if (toStr != null)
 			return toStr;
 
-		toStr = new String();
+		toStr = "";
 
 		for (int i = MRTConstants.ATTRIBUTE_AS_PATH; i <= MRTConstants.ATTRIBUTE_AGGREGATOR; i++) {
 			if (attributes.elementAt(i) != null) {

--- a/src/main/java/org/javamrt/mrt/Attributes.java
+++ b/src/main/java/org/javamrt/mrt/Attributes.java
@@ -10,7 +10,6 @@ import org.javamrt.utils.Debug;
 import org.javamrt.utils.RecordAccess;
 
 import java.net.InetAddress;
-import java.util.Arrays;
 import java.util.Vector;
 
 public class Attributes {
@@ -22,25 +21,27 @@ public class Attributes {
 		if (attrBytes != 2 && attrBytes != 4)
 			throw new AttributeException(String.format(
 					"Attributes needs attrBytes 2 or 4 (not %d", attrBytes));
-		decode(record, attrLen, attrPos, attrBytes);
-		bytes = Arrays.copyOfRange(record, attrPos, attrPos + attrLen);
+		bytes = new byte[attrLen];
+		System.arraycopy(record, attrPos, bytes, 0, attrLen);
+		decode(bytes, attrLen, attrBytes);
 	}
 
 	public Attributes(byte[] record, int attrLen, int attrPos) throws Exception {
-		decode(record, attrLen, attrPos, 2);
-		bytes = Arrays.copyOfRange(record, attrPos, attrPos + attrLen);
+		bytes = new byte[attrLen];
+		System.arraycopy(record, attrPos, bytes, 0, attrLen);
+		decode(bytes, attrLen, 2);
 	}
 
 	public byte[] getBytes() { return bytes; }
 
-	private void decode(byte[] record, int attrLen, int attrPos, int attrBytes)
+	private void decode(byte[] record, int attrLen, int attrBytes)
 			throws Exception {
 		byte[] buffer;
 
-		int here = attrPos;
+		int here = 0;
 
 		if (Debug.compileDebug)
-			Debug.printf("Attributes(...,%d,%d,%d)\n", attrLen, attrPos,
+			Debug.printf("Attributes(...,%d,%d,%d)\n", attrLen, 0,
 					attrBytes);
 
 		attributes = new Vector<Attribute>(MRTConstants.ATTRIBUTE_TOTAL);
@@ -51,7 +52,7 @@ public class Attributes {
 			else
 				attributes.addElement(null);
 
-		while (here < attrLen + attrPos) {
+		while (here < attrLen) {
 
 			int flag = RecordAccess.getU8(record, here);
 			int type = RecordAccess.getU8(record, here + 1);

--- a/src/main/java/org/javamrt/mrt/BGPFileReader.java
+++ b/src/main/java/org/javamrt/mrt/BGPFileReader.java
@@ -376,7 +376,6 @@ public class BGPFileReader implements Closeable {
 				Withdraw withdraw = new Withdraw(header, record, peerIP, peerAS, prefix, MRTConstants.UPDATE_STR_BGP);
                 recordFifo.add(withdraw);
             }
-        }else{ // Advertisments
 
             //Reading length of attributes
             int attrLen = RecordAccess.getU16(record, offset);
@@ -409,7 +408,6 @@ public class BGPFileReader implements Closeable {
                             aNlri, attributes, MRTConstants.UPDATE_STR_BGP));
                 }
             }
-        }
 
         return recordFifo.remove();
     }

--- a/src/main/java/org/javamrt/mrt/Bgp4Update.java
+++ b/src/main/java/org/javamrt/mrt/Bgp4Update.java
@@ -8,6 +8,7 @@ package org.javamrt.mrt;
 
 import java.net.InetAddress;
 import java.util.Comparator;
+import java.util.Objects;
 
 public class Bgp4Update
 	extends MRTRecord
@@ -49,7 +50,7 @@ public class Bgp4Update
 				.append(this.updateType).append('|')
 				.append(peerString).append('|')
 				.append(this.peerAS).append('|')
-				.append(this.prefix.toString());
+				.append(this.prefix == null ? "" : this.prefix.toString());
 
 		if (this.updateAttr != null)
 			result.append('|').append(this.updateAttr.toString());
@@ -70,11 +71,11 @@ public class Bgp4Update
 
 
 	public boolean isIPv4() {
-		return this.prefix.isIPv4();
+		return prefix != null && prefix.isIPv4();
 	}
 
 	public boolean isIPv6() {
-		return this.prefix.isIPv6();
+		return prefix != null && prefix.isIPv6();
 	}
 
 	public Prefix getPrefix() {
@@ -108,12 +109,12 @@ public class Bgp4Update
 	 * Order by prefixes, then by peer and then by time.
 	 */
 	public int compareTo(Bgp4Update other) {
-		int result = this.prefix.compareTo(other.prefix);
+		int result = Objects.compare(this.prefix, other.prefix, Prefix::compareTo);
 		if (result == 0) {
 			result = org.javamrt.utils.InetAddressComparator.compara(this.peerIP,
 					other.peerIP);
 			if (result == 0) {
-				result = Long.valueOf(this.getTime()).compareTo(other.getTime());
+				result = Long.compare(this.getTime(), other.getTime());
 /*
  *  Ignore sorting by update type
  *

--- a/src/main/java/org/javamrt/mrt/ClusterList.java
+++ b/src/main/java/org/javamrt/mrt/ClusterList.java
@@ -49,12 +49,14 @@ public class ClusterList implements Attribute {
 		return false;
 	}
 
-	public String toString() {
-		StringBuffer result = new StringBuffer();
+    public String toString() {
+        StringBuilder result = new StringBuilder();
 
-		for (int i = 0; i < clusterList.length; i++)
-			result.append(clusterList[i].getHostAddress() + " ");
+        for (final InetAddress aClusterList : clusterList) {
+            result.append(aClusterList.getHostAddress())
+                  .append(" ");
+        }
 
-		return result.toString();
-	}
+        return result.toString();
+    }
 }

--- a/src/main/java/org/javamrt/mrt/Community.java
+++ b/src/main/java/org/javamrt/mrt/Community.java
@@ -33,11 +33,11 @@ public class Community implements Attribute {
 	}
 
 	public String toString() {
-		return toStringBuffer(community).toString();
+		return toStringBuilder(community).toString();
 	}
 
-	private static StringBuffer toStringBuffer(byte[] buffer) {
-		StringBuffer result = new StringBuffer();
+	private static StringBuilder toStringBuilder(byte[] buffer) {
+		StringBuilder result = new StringBuilder();
 
 		if (null != buffer) {
 			int len = buffer.length;

--- a/src/main/java/org/javamrt/mrt/Community.java
+++ b/src/main/java/org/javamrt/mrt/Community.java
@@ -8,6 +8,8 @@ package org.javamrt.mrt;
 
 import org.javamrt.utils.RecordAccess;
 
+import java.util.Arrays;
+
 
 public class Community implements Attribute {
 	static final private int BGP_ATTR_COMMUNITY_NO_EXPORT = 0xFFFFFF01;
@@ -23,8 +25,7 @@ public class Community implements Attribute {
 
 	public Community(byte[] buffer) {
 		community = new byte[buffer.length];
-		for (int i = 0; i < buffer.length; i++)
-			community[i] = buffer[i];
+		System.arraycopy(buffer, 0, community, 0, buffer.length);
 	}
 
 	public static Community empty() {
@@ -66,12 +67,7 @@ public class Community implements Attribute {
 	}
 
 	public boolean equals(Community other) {
-		if (this.community.length != other.community.length)
-			return false;
-		for (int i = 0; i < this.community.length; i++)
-			if (this.community[i] != other.community[i])
-				return false;
-		return true;
+		return Arrays.equals(this.community, other.community);
 	}
 
 	public boolean equals(Object o) {

--- a/src/main/java/org/javamrt/mrt/EndOfRib.java
+++ b/src/main/java/org/javamrt/mrt/EndOfRib.java
@@ -1,0 +1,24 @@
+package org.javamrt.mrt;
+
+import java.net.InetAddress;
+
+public class EndOfRib extends Bgp4Update {
+    protected char updateType = 0;
+
+    public EndOfRib(byte[] header, byte[] record, InetAddress peerIP, AS peerAS, String updateStr) {
+        super(header, record, peerIP, peerAS, null, updateStr);
+    }
+
+    public EndOfRib(byte[] header, byte[] record, InetAddress peerIP, AS peerAS, Attributes updateAttr, String updateStr) {
+        super(header, record, peerIP, peerAS, null, updateAttr, updateStr);
+    }
+
+    @Override
+    public String toString() {
+        String peerString = MRTConstants.ipAddressString(this.peerIP, false);
+        String attrString = updateAttr == null ? "" : updateAttr.toString();
+
+        return String.format("%s|%s||%s|%s|%s",
+                updateStr, getTime(), peerString, peerAS, attrString);
+    }
+}

--- a/src/main/java/org/javamrt/mrt/KeepAlive.java
+++ b/src/main/java/org/javamrt/mrt/KeepAlive.java
@@ -6,15 +6,61 @@
 
 package org.javamrt.mrt;
 
-public class KeepAlive extends MRTRecord
-{
-  KeepAlive (byte[]header, byte[]record)
-  {
-    super (header, record);
-  }
+import java.net.InetAddress;
+import java.util.Objects;
 
-  public String toString ()
-  {
-    return "KEEP_ALIVE";
-  }
+public class KeepAlive extends MRTRecord {
+    private final AS peerAs;
+    private final InetAddress peerIp;
+    private final AS localAs;
+    private final InetAddress localIp;
+
+    KeepAlive(byte[] header, byte[] record, AS peerAs, InetAddress peerIp, AS localAs, InetAddress localIp) {
+        super(header, record);
+        this.peerAs = peerAs;
+        this.peerIp = peerIp;
+        this.localAs = localAs;
+        this.localIp = localIp;
+    }
+
+    @Override
+    public InetAddress getPeer() {
+        return peerIp;
+    }
+
+    @Override
+    public AS getPeerAS() {
+        return peerAs;
+    }
+
+    public AS getLocalAs() {
+        return localAs;
+    }
+
+    public InetAddress getLocalIp() {
+        return localIp;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("KEEP_ALIVE|%d|%s|%s",
+   				getTime(), MRTConstants.ipAddressString(peerIp, false), peerAs);
+   	}
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final KeepAlive keepAlive = (KeepAlive) o;
+        return getTime() == keepAlive.getTime() &&
+                Objects.equals(peerAs, keepAlive.peerAs) &&
+                Objects.equals(peerIp, keepAlive.peerIp) &&
+                Objects.equals(localAs, keepAlive.localAs) &&
+                Objects.equals(localIp, keepAlive.localIp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(peerAs, peerIp, localAs, localIp);
+    }
 }

--- a/src/main/java/org/javamrt/mrt/LenientPrefix.java
+++ b/src/main/java/org/javamrt/mrt/LenientPrefix.java
@@ -1,0 +1,36 @@
+package org.javamrt.mrt;
+
+import org.javamrt.progs.route_btoa;
+import org.javamrt.utils.RecordAccess;
+
+import java.net.InetAddress;
+
+public class LenientPrefix extends Prefix {
+
+    public LenientPrefix(byte[] record, int offset, int afi) {
+        super();
+        maskLength = RecordAccess.getU8(record, offset++);
+        if (afi != MRTConstants.AFI_IPv4 && afi != MRTConstants.AFI_IPv6) {
+            route_btoa.System_err_println("Unknown AFI: " + afi + ". Assuming IPv4.");
+        }
+        base = new byte[afi == MRTConstants.AFI_IPv6 ? 16 : 4];
+        mask = new byte[afi == MRTConstants.AFI_IPv6 ? 16 : 4];
+        if (offset + nrBytes() > record.length) {
+            throw new ArrayIndexOutOfBoundsException(String.format(
+                    "Not enough input bytes (%s) to read NLRI prefix (%d bytes from offset %d)",
+                    RecordAccess.arrayToString(record), nrBytes(), offset));
+        }
+        System.arraycopy(record, offset, base, 0, nrBytes());
+        isInIpv4EmbeddedIpv6Format = MRTConstants.isInIpv4EmbeddedIpv6Format(this.base);
+    }
+
+    @Override
+    public InetAddress getBroadcastAddress() {
+        throw new UnsupportedOperationException("Not implemented in a lenient prefix");
+    }
+
+    @Override
+    protected boolean matches(byte[] addr) {
+        throw new UnsupportedOperationException("Not implemented in a lenient prefix");
+    }
+}

--- a/src/main/java/org/javamrt/mrt/LocalPref.java
+++ b/src/main/java/org/javamrt/mrt/LocalPref.java
@@ -15,7 +15,7 @@ public class LocalPref implements Attribute {
 	}
 
 	public String toString() {
-		return "" + localPref;
+		return Long.toString(localPref);
 	}
 
 	public long getLocalPref() {

--- a/src/main/java/org/javamrt/mrt/MRTConstants.java
+++ b/src/main/java/org/javamrt/mrt/MRTConstants.java
@@ -10,6 +10,7 @@ package org.javamrt.mrt;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 
@@ -122,14 +123,19 @@ public class MRTConstants {
 	public static final int BGP4MSG_REFRESH = 5;
 
 	public static final int BGPDUMP_TYPE_MRTD_BGP = 5;
+	public static final int BGPDUMP_SUBTYPE_MRTD_BGP_NULL= 0;
 	public static final int BGPDUMP_SUBTYPE_MRTD_BGP_UPDATE= 1;
+	public static final int BGPDUMP_SUBTYPE_MRTD_BGP_PREF_UPDATE= 2;
 	public static final int BGPDUMP_SUBTYPE_MRTD_BGP_STATE_CHANGE = 3;
+	public static final int BGPDUMP_SUBTYPE_MRTD_BGP_SYNC = 4;
+	public static final int BGPDUMP_SUBTYPE_MRTD_BGP_OPEN = 5;
+	public static final int BGPDUMP_SUBTYPE_MRTD_BGP_NOTIFY = 6;
 	public static final int BGPDUMP_SUBTYPE_MRTD_BGP_KEEPALIVE = 7;
 
 	public static final String UPDATE_STR_BGP4MP = "BGP4MP";
 	public static final String UPDATE_STR_BGP = "BGP";
 
-	public static final String mpSubType(int s) {
+	public static String mpSubType(int s) {
 		switch (s) {
 		case BGP4MP_STATE_CHANGE:
 			return "BGP4MP_STATE_CHANGE";
@@ -148,7 +154,7 @@ public class MRTConstants {
 		}
 	}
 
-	public static final String attrFlags(byte attr) {
+	public static String attrFlags(byte attr) {
 		String result = "";
 		if (0 != (attr & BGP_ATTR_FLAG_OPTIONAL)) result = result + "OPTIONAL ";
 		if (0 != (attr & BGP_ATTR_FLAG_TRANS))    result = result + "TRANSITIVE ";
@@ -167,7 +173,7 @@ public class MRTConstants {
 		"BGP4MSG_REFRESH"
 	};
 
-	public static final String bgpType(int bgpType) {
+	public static String bgpType(int bgpType) {
 		try {
 			return bgpTypes[bgpType];
 		} catch (Exception e) {
@@ -187,7 +193,7 @@ public class MRTConstants {
 	 *
 	 * It looks if it is an ipv4 embedded in ipv6
 	 */
-	public static final boolean isInIpv4EmbeddedIpv6Format(InetAddress ia, int afi){
+	public static boolean isInIpv4EmbeddedIpv6Format(InetAddress ia, int afi){
 		if(ia instanceof Inet4Address && afi == AFI_IPv6){
 			return true;
 		}
@@ -204,7 +210,7 @@ public class MRTConstants {
 	 *
 	 * It looks if it is an ipv4 embedded in ipv6
 	 */
-	public static final boolean isInIpv4EmbeddedIpv6Format(byte[] base) {
+	public static boolean isInIpv4EmbeddedIpv6Format(byte[] base) {
 		try {
 			InetAddress ia = InetAddress.getByAddress(base);
 			if (ia instanceof Inet4Address && base.length == IPv6_LENGTH) {
@@ -213,8 +219,8 @@ public class MRTConstants {
 			if (ia instanceof Inet6Address && ((Inet6Address)ia).isIPv4CompatibleAddress()) {
 				return true;
 			}
-		}catch(Exception e) {
-		    e.printStackTrace();
+		} catch (UnknownHostException e) {
+			throw new RuntimeException(e);
 		}
 		return false;
 	}
@@ -228,18 +234,12 @@ public class MRTConstants {
 	 *
 	 * for all addresses, removes initial name
 	 */
-	public static final String ipAddressString(InetAddress inetAddress, boolean isIpv4EmbeddedIpv6) {
-//		String ipAddressString = inetAddress.getHostAddress().
-//				// replaceFirst("^[^/]*/", "").
-//						replaceFirst(":0(:0)+", "::").
-//						replaceFirst("^0:", "").
-//						replaceFirst(":::", "::");
+	public static String ipAddressString(InetAddress inetAddress, boolean isIpv4EmbeddedIpv6) {
+	    if (inetAddress == null) return "";
 
 		String ipAddressString = inetAddress.getHostAddress();
 		try {
-
 			if (isIpv4EmbeddedIpv6) {
-
 				if(inetAddress instanceof Inet4Address)
 					ipAddressString = "::ffff:" + ipAddressString;
 				else if (inetAddress instanceof Inet6Address){
@@ -252,19 +252,19 @@ public class MRTConstants {
 
 			if (ipAddressString.equals(":"))
 				ipAddressString = "::";
-		}catch(Exception e){
-            e.printStackTrace();
+		} catch (UnknownHostException e) {
+			throw new RuntimeException(e);
 		}
 
 		return ipAddressString;
 	}
 
-	public static final String ipAddressString(byte[] ipAddressBase, boolean isIpv4EmbeddedIpv6){
-		try{
-			return ipAddressString(InetAddress.getByAddress(ipAddressBase), isIpv4EmbeddedIpv6);
-		}catch(Exception e){
-			e.printStackTrace();
-			return new String("??/");
-		}
-	}
+    public static String ipAddressString(byte[] ipAddressBase, boolean isIpv4EmbeddedIpv6) {
+        try {
+            return ipAddressString(InetAddress.getByAddress(ipAddressBase), isIpv4EmbeddedIpv6);
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+            return "??/";
+        }
+    }
 }

--- a/src/main/java/org/javamrt/mrt/MRTRecord.java
+++ b/src/main/java/org/javamrt/mrt/MRTRecord.java
@@ -13,8 +13,8 @@ import java.util.Arrays;
 
 
 public class MRTRecord {
-	protected byte[] header;
-	protected byte[] body;
+	final protected byte[] header;
+	final protected byte[] body;
 
 	protected MRTRecord(byte[] header, byte[] body) {
 		this.header = header;

--- a/src/main/java/org/javamrt/mrt/MalformedBgpStreamException.java
+++ b/src/main/java/org/javamrt/mrt/MalformedBgpStreamException.java
@@ -1,0 +1,18 @@
+package org.javamrt.mrt;
+
+import java.io.IOException;
+
+/**
+ * Thrown if the input stream of data is broken in a way that is not possible to read any more MRT records from it.
+ * Therefore you should not try to call BGPFileReader.readNext() on the same input anymore.
+ * All other exceptions are potentially local to the MRT record they are thrown for, so the readNext() should be possible.
+ */
+public class MalformedBgpStreamException extends IOException {
+    public MalformedBgpStreamException(Throwable e) {
+        super(e);
+    }
+
+    public MalformedBgpStreamException(String s) {
+        super(s);
+    }
+}

--- a/src/main/java/org/javamrt/mrt/OriginatorID.java
+++ b/src/main/java/org/javamrt/mrt/OriginatorID.java
@@ -16,7 +16,7 @@ public class OriginatorID implements Attribute {
 	}
 
 	public String toString() {
-		return "" + id;
+		return Long.toString(id);
 	}
 
 	public long originatorId() {

--- a/src/main/java/org/javamrt/mrt/Prefix.java
+++ b/src/main/java/org/javamrt/mrt/Prefix.java
@@ -14,7 +14,7 @@ import java.util.Comparator;
 
 public class Prefix implements Comparable<Prefix>, Comparator<Prefix> {
 
-	private boolean isInIpv4EmbeddedIpv6Format = false;
+	protected boolean isInIpv4EmbeddedIpv6Format = false;
 
 	// for Nlri.java
 	protected byte[] base;
@@ -25,14 +25,7 @@ public class Prefix implements Comparable<Prefix>, Comparator<Prefix> {
 	// protected InetAddress broadcastAddress;
 	protected int maskLength;
 
-	protected Prefix() {
-		//baseAddress = null;
-		//broadcastAddress = null;
-		this.base       = null;
-		this.mask       = null;
-		this.broadcast  = null;
-		this.maskLength = 0;
-	}
+	protected Prefix() {/* for inheritance*/}
 
 	public Prefix(InetAddress addr, int maskLength)
 			throws PrefixMaskException, UnknownHostException {
@@ -75,10 +68,7 @@ public class Prefix implements Comparable<Prefix>, Comparator<Prefix> {
 			throw new PrefixMaskException(this.base, this.maskLength);
 		}
 		*/
-		for (int n = 0; n < this.mask.length; n++) {
-			this.base[n] = addr[n];
-			this.mask[n] = 0;
-		}
+		System.arraycopy(addr, 0, this.base, 0, this.mask.length);
 		for (int n = this.maskLength; n > 0; n--) {
 			for (int i = 0; i < this.mask.length; i++) {
 				byte carry = (byte) (this.mask[i] & 0x01);
@@ -167,7 +157,7 @@ public class Prefix implements Comparable<Prefix>, Comparator<Prefix> {
 			return MRTConstants.ipAddressString(this.base, isInIpv4EmbeddedIpv6Format).
 				concat("/" + this.maskLength);
 		} catch (Exception e) {
-			return new String("??/"+this.maskLength);
+			return "??/" + this.maskLength;
 		}
 	}
 
@@ -218,5 +208,19 @@ public class Prefix implements Comparable<Prefix>, Comparator<Prefix> {
 			if (base[i] != 0)
 				return false;
 		return true;
+	}
+
+	/**
+	 * @return number of bytes required to represent this prefix
+	 */
+	public int nrBytes() {
+		return maskLength > 0 ? 1 + (maskLength - 1) / 8 : 0;
+	}
+
+	/**
+	 * @return the number of bytes needed to represent this prefix, plus one
+	 */
+	public int getOffset() {
+		return 1 + nrBytes();
 	}
 }

--- a/src/main/java/org/javamrt/mrt/PrefixMaskException.java
+++ b/src/main/java/org/javamrt/mrt/PrefixMaskException.java
@@ -32,9 +32,10 @@ public class PrefixMaskException
 		}
 	}
 
-    public String toString() {
-    	return new String(description);
-    }
+	@Override
+	public String getMessage() {
+		return description;
+	}
 
 	private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/org/javamrt/mrt/RFC4893.java
+++ b/src/main/java/org/javamrt/mrt/RFC4893.java
@@ -48,9 +48,19 @@ public class RFC4893 {
 		 *    for the AS4_PATH attribute.
          */
 
-		for (AS as4:as4path.path) {
-			if (as4 instanceof ASConfedSet || as4 instanceof ASConfedSequence)
-				throw new RFC4893Exception(MRTConstants.asConfedSequence, aspath,as4path);
+		for (AS as4 : as4path.path) {
+			if (as4 instanceof ASConfedSet || as4 instanceof ASConfedSequence) {
+				if (BGPFileReader.isLenient()) {
+					route_btoa.System_err_println(String.format("RFC4893 violation with AS4PATH containing %s%n" +
+									"  while trying to modify: %s%n" +
+									"  with 4 byte ASPATH:     %s",
+							MRTConstants.asPathString(MRTConstants.asConfedSequence),
+							aspath,
+							as4path));
+				} else {
+					throw new RFC4893Exception(MRTConstants.asConfedSequence, aspath,as4path);
+				}
+			}
 		}
 
 		if (DEBUG) {

--- a/src/main/java/org/javamrt/mrt/RFC4893Exception.java
+++ b/src/main/java/org/javamrt/mrt/RFC4893Exception.java
@@ -80,7 +80,8 @@ public class RFC4893Exception extends Exception {
 		return this.as4path;
 	}
 
-	public String toString() {
+	@Override
+	public String getMessage() {
 		if (peer == null || as == null)
 			return String.format("RFC4893 violation @ %d: AS4PATH contains %s",this.timestamp,MRTConstants.asPathString(cause));
 		return String.format(

--- a/src/main/java/org/javamrt/progs/route_btoa.java
+++ b/src/main/java/org/javamrt/progs/route_btoa.java
@@ -242,7 +242,9 @@ public class route_btoa {
         if (outputErrToBuilder) {
             errBuilder.append(str).append(System.lineSeparator());
         } else {
+            System.out.flush();
             System.err.println(str);
+            System.err.flush();
         }
     }
 

--- a/src/test/java/org/javamrt/mrt/ASPathTest.java
+++ b/src/test/java/org/javamrt/mrt/ASPathTest.java
@@ -132,5 +132,4 @@ public class ASPathTest {
 
         return result;
     }
-
 }

--- a/src/test/java/org/javamrt/mrt/ASTest.java
+++ b/src/test/java/org/javamrt/mrt/ASTest.java
@@ -2,6 +2,9 @@ package org.javamrt.mrt;
 
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 import static org.testng.AssertJUnit.assertEquals;
 
 public class ASTest {
@@ -78,5 +81,15 @@ public class ASTest {
         assertEquals(false, new AS(65535L).is4Byte());
         assertEquals(true, new AS(65536L).is4Byte());
         assertEquals(true, new AS(0xFFFFFFFFL).is4Byte());
+    }
+
+    @Test
+    public void getAsList() {
+        final AS as1 = new AS(1L);
+        final AS as2 = new AS(2L);
+        assertEquals(Collections.singletonList(as1), as1.getASList());
+        assertEquals(Arrays.asList(as1, as2), new ASSet(Arrays.asList(as1, as2)).getASList());
+        assertEquals(Arrays.asList(as1, as2), new ASConfedSet(Arrays.asList(as1, as2)).getASList());
+        assertEquals(Arrays.asList(as1, as2), new ASConfedSequence(Arrays.asList(as1, as2)).getASList());
     }
 }

--- a/src/test/java/org/javamrt/mrt/MrtTest.java
+++ b/src/test/java/org/javamrt/mrt/MrtTest.java
@@ -168,4 +168,24 @@ public class MrtTest {
         assertEquals(mrtRecord.getClass(), Advertisement.class);
         assertEquals(mrtRecord.toString(), "BGP4MP|1361492792|A|2001:7f8:4:0:0:0:232a:1|9002|2001:9b8:0:0:0:0:0:0/32|9002 6774|IGP|2001:7f8:4:0:0:0:1a76:1|0|0||NAG||");
     }
+
+    @Test
+    public void should_parse_ipv4_end_of_rib() throws Exception {
+        final byte[] bytes = new byte[] {91,15,-4,42,0,16,0,4,0,0,0,43,0,4,5,-96,0,0,49,110,0,0,0,1,-69,16,-36,-63,-69,16,-40,23,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,0,23,2,0,0,0,0};
+        final ByteArrayInputStream stream = new ByteArrayInputStream(bytes);
+        final BGPFileReader bgpFileReader = new BGPFileReader(stream);
+        final MRTRecord mrtRecord = bgpFileReader.readNext();
+        assertEquals(mrtRecord.getClass(), EndOfRib.class);
+        assertEquals(mrtRecord.toString(), "BGP4MP|1527774250||187.16.220.193|263584|");
+    }
+
+    @Test
+    public void should_parse_ipv6_end_of_rib() throws Exception {
+        final byte[] bytes = new byte[] {91,16,-4,-111,0,16,0,4,0,0,0,73,0,0,-77,72,0,0,49,110,0,0,0,2,32,1,13,-16,2,-24,16,0,0,0,0,0,0,0,0,1,32,1,6,124,2,-24,0,2,-1,-1,0,0,0,4,0,40,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,0,29,2,0,0,0,6,-128,15,3,0,2,1};
+        final ByteArrayInputStream stream = new ByteArrayInputStream(bytes);
+        final BGPFileReader bgpFileReader = new BGPFileReader(stream);
+        final MRTRecord mrtRecord = bgpFileReader.readNext();
+        assertEquals(mrtRecord.getClass(), EndOfRib.class);
+        assertEquals(mrtRecord.toString(), "BGP4MP|1527839889||2001:df0:2e8:1000:0:0:0:1|45896|||255.255.255.255|0|0||NAG||");
+    }
 }


### PR DESCRIPTION
Multiple fixes and improvements:
- Fix byte array re-use between consequently parsed objects
- Add support for all remaining subtypes of (deprecated) BGP type
- Add lenient parse mode (to parse dump files generated by broken versions of Zebra/Quagga)
- Minor bug fixes